### PR TITLE
Remove return false onSubmit file upload

### DIFF
--- a/js/sam-admin-edit-item.js
+++ b/js/sam-admin-edit-item.js
@@ -255,7 +255,7 @@ var sam = sam || {};
         }
         loadImg.show();
         status.text(samStrs.uploading);
-        return false;
+        
       },
       onComplete:function (file, response) {
         status.text('');


### PR DESCRIPTION
If the onSubmit function returns false, the file is not uploaded.
